### PR TITLE
feat(deep manifest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,38 @@
 Parcel plugin for generating an bundle manifest.
 
 Usage
-=======
+========
 
-### install
+## install
 
 ```
 npm install --save-dev parcel-plugin-bundle-manifest
 ```
 
-### build
+## build
 
 ```
 parcel build entry.js
 ```
 
-### output
+## Output
 
-output manifest file to same directory as the bundle file.
+Output a `parcel-manifest.json` file to the same directory as the bundle file.
 
-- dist/entry.js
-- dist/entry-{hash}.js
+- dist/entry.html
+- dist/{hash}.js
+- dist/{hash}.css
 - dist/parcel-manifest.json
+
+The Manifest will look like this : 
+
+```json
+{
+  "index.html": "/dist/index.html",
+  "index.js": "/dist/5f0796534fe2892712053b3a035f585b.js",
+  "main.scss": "/dist/5f0796534fe2892712053b3a035f585b.css"
+}
+```
 
 License
 ========


### PR DESCRIPTION
Make the manifest.json behave like webpack 

```json
{
  "index.html": "/dist/index.html",
  "index.js": "/dist/5f0796534fe2892712053b3a035f585b.js",
  "main.scss": "/dist/5f0796534fe2892712053b3a035f585b.css"
}
```

I made it recursive so it will output every generated assets (usefull if you want to use this with server generated content). Tell me if you don't agree with this change (I'll publish another package).