### PR TITLE
Fixes the logger

### DIFF
--- a/plugins/BundleManifestPlugin.js
+++ b/plugins/BundleManifestPlugin.js
@@ -1,9 +1,9 @@
 const path = require('path');
 const hasha = require('hasha');
 const fs = require('fs');
+const logger = require('parcel-bundler/src/Logger');
 
 module.exports = function (bundler) {
-  const logger = bundler.logger;
 
   /**
    * Read the paths already registered within the manifest.json


### PR DESCRIPTION
The bundler does not have `bundle.logger` in newer version of Parcel.

The logger must be required from a module.