### PR TITLE
Fix for bundles with no input files

### DIFF
--- a/plugins/BundleManifestPlugin.js
+++ b/plugins/BundleManifestPlugin.js
@@ -34,8 +34,11 @@ module.exports = function (bundler) {
    */
   const feedManifestValue = (bundle, manifestValue, publicURL) => {
     let output = path.join(publicURL, path.basename(bundle.name));
-    let input = bundle.entryAsset ? bundle.entryAsset.basename : bundle.assets.values().next().value.basename;
-    if(!manifestValue[input]) {
+    const input = 
+      bundle.entryAsset ? bundle.entryAsset.basename : 
+      bundle.assets.size ? bundle.assets.values().next().value.basename : 
+      null;
+    if(input && !manifestValue[input]) {
       manifestValue[input] = output;
       logger.status('✓', `  bundle : ${input} => ${output}`);
     }


### PR DESCRIPTION
It seems like parcel generates a bundle internally which has no input files.  We can just skip this bundle for purposes of building the manifest.

Fixes https://github.com/mugi-uno/parcel-plugin-bundle-manifest/issues/5