### PR TITLE
fix output with absolute publicURL

### DIFF
--- a/plugins/BundleManifestPlugin.js
+++ b/plugins/BundleManifestPlugin.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const fs = require('fs');
+const url = require('url');
 
 module.exports = function (bundler) {
 
@@ -31,7 +32,7 @@ module.exports = function (bundler) {
    * @param {string} publicURL 
    */
   const feedManifestValue = (bundle, manifestValue, publicURL) => {
-    let output = path.join(publicURL, path.basename(bundle.name));
+    let output = url.resolve(publicURL, path.basename(bundle.name));
 
     if(isServiceWorkerFile(output)) {
       return;
@@ -58,7 +59,9 @@ module.exports = function (bundler) {
 
   function entryPointHandler(bundle) {
     const dir = bundler.options.outDir;
-    const publicURL = bundler.options.publicURL;
+    const publicURL = bundler.options.publicURL.endsWith('/')
+      ? bundler.options.publicURL
+      : bundler.options.publicURL + '/';
 
     const manifestPath = path.resolve(dir, 'parcel-manifest.json');
     const manifestValue = {}

--- a/spec/spec.absolutePublicURL/index.html
+++ b/spec/spec.absolutePublicURL/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+</head>
+<body>  
+</body>
+</html>

--- a/spec/spec.absolutePublicURL/index.spec.js
+++ b/spec/spec.absolutePublicURL/index.spec.js
@@ -1,0 +1,21 @@
+const { createBundler, createTester } = require('../utils');
+
+const tester = createTester(__dirname);
+
+describe('absolute publicURL', () => {
+  beforeEach(() => {
+    tester.cleanDist();
+  });
+
+  test('absolute publicURL', async () => {
+    const publicURL = 'https://example.com';
+    const option = Object.assign({}, tester.option, { publicURL });
+
+    await createBundler(__dirname + '/index.html', option).bundle();
+
+    const json = await tester.readManifest();
+
+    expect(Object.keys(json)).toHaveLength(1);
+    expect(json['index.html']).toBe(`${publicURL}/index.html`);
+  });
+});


### PR DESCRIPTION
`path.join` returns incorrect URL when publicURL is absolute (and also on Windows):
```
https:/example.com/index.html (Linux)
https:\example.com\index.html (Windows)
```
`url.resolve` returns correct URL:
```
https://example.com/index.html (Linux)
https://example.com/index.html (Windows)
```